### PR TITLE
Fix saveNetworks()

### DIFF
--- a/src/Model/Settings.php
+++ b/src/Model/Settings.php
@@ -247,7 +247,7 @@ class Settings extends AbstractModel
         foreach ($this->networks as $network) {
             $network->save($this->account, $this->transferKey);
             if ($network->error) {
-                $errors[$network->abbr] = $network->error;
+                $errors[$network->network] = $network->error;
             }
         }
 


### PR DESCRIPTION
Uses network as a key in the errors array when saving networks instead of abbr